### PR TITLE
Adding support for more block devices (e.g. NVMe).

### DIFF
--- a/boxinfo.pl
+++ b/boxinfo.pl
@@ -653,7 +653,7 @@ sub gather_mounts {
             if ($line =~ m{^(.+?) on (.+?) type (.+?) \((.+)\)\s*(.*)}) {
                 my ($dev,$dir,$type,$options,$label) = ($1,$2,$3,$4,$5);
                 $data{fs}{$dev} = {dir => $dir, type => $type, options => $options, readahead => '', scheduler => ''};
-                if ($dev =~ m{^\/dev\/([a-z]+)\d*$}) {
+                if ($dev =~ m{^\/dev\/([a-z0-9]+?)p*\d*$}) {
                     my $name = $1;
                     if (! exists $data{block}{$name}) {
                         run_command("cat /sys/block/$name/queue/read_ahead_kb", 'tmp_readahead');


### PR DESCRIPTION
This takes care of my case:

$ lsblk /dev/nvme0n1
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
nvme0n1     259:0    0   477G  0 disk
├─nvme0n1p1 259:1    0   127M  0 part /boot
└─nvme0n1p2 259:2    0 124.9G  0 part /

However, a better general solution will be to use the lsblk(8) command
altogether.
